### PR TITLE
Update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ You need to copy `username`, `password`.
 [german_twitter]: https://twitter.com/germanatt
 [nathan_twitter]: https://twitter.com/nfriedly
 [pi_docs]: http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/personality-insights/
-[vcap_environment]: https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/#VcapEnvVar
+[vcap_environment]: https://www.ibm.com/watson/developercloud/doc/common/getting-started-variables.html


### PR DESCRIPTION

- getting_started content moved with conversion to Markdown
- Original link was not correct to start with (had anchor, but not
correct file name)